### PR TITLE
fixed connection deprecation warnings

### DIFF
--- a/db-mongoose.js
+++ b/db-mongoose.js
@@ -6,7 +6,8 @@ mongoose.Promise = global.Promise;
 const { DATABASE_URL } = require('./config');
 
 function dbConnect(url = DATABASE_URL) {
-  return mongoose.connect(url)
+  return mongoose.connect(url, { useNewUrlParser: true, useCreateIndex: true
+  })
     .catch(err => {
       console.error('Mongoose failed to connect');
       console.error(err);


### PR DESCRIPTION
When you get the warnings below, 
```
(node:42561) DeprecationWarning: current URL string parser is deprecated, and will be removed in a future version. To use the new parser, pass option { useNewUrlParser: true } to MongoClient.connect.
App listening on port 8080
(node:42561) DeprecationWarning: collection.ensureIndex is deprecated. Use createIndexes instead.
```
here's the fix: 
- ` return mongoose.connect(url, { useNewUrlParser: true, useCreateIndex: true
  })`